### PR TITLE
✨ Create a artists page & make (small) adjustments

### DIFF
--- a/lib/components/artistlist/ArtistList.dart
+++ b/lib/components/artistlist/ArtistList.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+
+import 'package:on_audio_query/on_audio_query.dart';
+
+class ArtistList extends StatefulWidget {
+  const ArtistList({Key? key}) : super(key: key);
+
+  @override
+  _ArtistListState createState() => _ArtistListState();
+}
+
+class _ArtistListState extends State<ArtistList> {
+  var audioQuery = OnAudioQuery();
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<List<ArtistModel>>(
+      future: OnAudioQuery().queryArtists(
+        sortType: ArtistSortType.DEFAULT,
+        orderType: OrderType.ASC_OR_SMALLER,
+        uriType: UriType.EXTERNAL,
+      ),
+      builder: (context, item) {
+        // Loading content
+        if (item.data == null)
+          return Center(child: CircularProgressIndicator());
+
+        if (item.data!.isEmpty) return Text("Nobody found!");
+
+        return ListView.builder(
+          itemCount: item.data!.length,
+          itemBuilder: (context, index) {
+            return ListTile(
+              title: Text(item.data![index].artist
+                  .replaceFirst("<unknown>", "Unknown Artist")),
+              subtitle: Text(
+                  item.data![index].numberOfAlbums.toString() + " Album(s)"),
+            );
+          },
+        );
+      },
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,10 +1,11 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
-import 'components/audiolist/AudioList.dart';
-
 import 'pages/settingspage.dart';
-import 'pages/titles.dart';
+import 'pages/libary.dart';
+import 'pages/artists/artists.dart';
 
 void main() {
   runApp(MyApp());
@@ -63,9 +64,21 @@ class _MyHomePageState extends State<MyHomePage> {
               'Libary',
               style: TextStyle(fontWeight: FontWeight.bold, fontSize: 18.00),
             ),
+            leading: Icon(Icons.library_music),
             onTap: () {
               Navigator.push(
-                  context, MaterialPageRoute(builder: (context) => Titles()));
+                  context, MaterialPageRoute(builder: (context) => Libary()));
+            },
+          ),
+          ListTile(
+            title: Text(
+              'Artists',
+              style: TextStyle(fontWeight: FontWeight.bold, fontSize: 18.00),
+            ),
+            leading: Icon(Icons.group),
+            onTap: () {
+              Navigator.push(
+                  context, MaterialPageRoute(builder: (context) => Artists()));
             },
           ),
         ],

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 import 'pages/settingspage.dart';
-import 'pages/libary.dart';
+import 'pages/library.dart';
 import 'pages/artists/artists.dart';
 
 void main() {
@@ -61,13 +61,13 @@ class _MyHomePageState extends State<MyHomePage> {
         children: [
           ListTile(
             title: Text(
-              'Libary',
+              'Library',
               style: TextStyle(fontWeight: FontWeight.bold, fontSize: 18.00),
             ),
             leading: Icon(Icons.library_music),
             onTap: () {
               Navigator.push(
-                  context, MaterialPageRoute(builder: (context) => Libary()));
+                  context, MaterialPageRoute(builder: (context) => Library()));
             },
           ),
           ListTile(

--- a/lib/pages/artists/artist-detail.dart
+++ b/lib/pages/artists/artist-detail.dart
@@ -1,0 +1,3 @@
+import 'package:flutter/material.dart';
+
+// TODO: detail view for each artists with all albums, titles etc.

--- a/lib/pages/artists/artists.dart
+++ b/lib/pages/artists/artists.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+
+import 'artist-detail.dart';
+import '../../components/artistlist/ArtistList.dart';
+
+class Artists extends StatefulWidget {
+  const Artists({Key? key}) : super(key: key);
+
+  @override
+  _ArtistsState createState() => _ArtistsState();
+}
+
+class _ArtistsState extends State<Artists> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        leading: IconButton(
+          onPressed: () {
+            Navigator.pop(context);
+          },
+          icon: Icon(
+            Icons.arrow_back,
+            color: Colors.grey[700],
+          ),
+        ),
+        centerTitle: true,
+        title: Text(
+          "Artists",
+          style: TextStyle(fontWeight: FontWeight.bold),
+        ),
+        elevation: 0.5,
+      ),
+      body: Container(
+        child: ArtistList(),
+      ),
+    );
+  }
+}

--- a/lib/pages/libary.dart
+++ b/lib/pages/libary.dart
@@ -1,16 +1,14 @@
 import 'package:flutter/material.dart';
 import '../components/audiolist/AudioList.dart';
 
-import 'settingspage.dart';
-
-class Titles extends StatefulWidget {
-  const Titles({Key? key}) : super(key: key);
+class Libary extends StatefulWidget {
+  const Libary({Key? key}) : super(key: key);
 
   @override
-  _TitlesState createState() => _TitlesState();
+  _LibaryState createState() => _LibaryState();
 }
 
-class _TitlesState extends State<Titles> {
+class _LibaryState extends State<Libary> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(

--- a/lib/pages/library.dart
+++ b/lib/pages/library.dart
@@ -1,14 +1,14 @@
 import 'package:flutter/material.dart';
 import '../components/audiolist/AudioList.dart';
 
-class Libary extends StatefulWidget {
-  const Libary({Key? key}) : super(key: key);
+class Library extends StatefulWidget {
+  const Library({Key? key}) : super(key: key);
 
   @override
-  _LibaryState createState() => _LibaryState();
+  _LibraryState createState() => _LibraryState();
 }
 
-class _LibaryState extends State<Libary> {
+class _LibraryState extends State<Library> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -24,7 +24,7 @@ class _LibaryState extends State<Libary> {
         ),
         centerTitle: true,
         title: Text(
-          "Libary",
+          "Library",
           style: TextStyle(fontWeight: FontWeight.bold),
         ),
         elevation: 0.5,


### PR DESCRIPTION
This brings a page that lists all artists and smaller adjustments to the app:

## artists page
- create list of artists (seperate component)
- created little scaffold for the Artist-Detail page


## adjustments
- **Titles** renamed to **Library**
	- renamed `lib/pages/titles.dart` to `lib/pages/library.dart`
	- renamed related widget name to Library
- add leading icons to the navigation

## screenshots
<div align="center">
<img alt="homescreen" src="https://user-images.githubusercontent.com/47633893/131335254-97793c13-7e89-4d71-9338-992700b95a2c.png" width="45%" />

<img alt="artists" src="https://user-images.githubusercontent.com/47633893/131335303-e4de6334-3f00-4183-9183-bbb0187df540.png" width="45%" />
</div>

